### PR TITLE
Deploy on heroku v2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: deno run --allow-net --allow-read --cached-only server.js --port=${PORT}

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 ## Demo
 
-### Join to chat page
-![Chat join page](https://i.imgur.com/BCXT0Ba.png)
-
-### Chat page
-![Chat page](https://i.imgur.com/h0FE6pY.png)
+#### Check [the following link](https://deno-websocket-chat.herokuapp.com/chat.html) to see deployed version on heroku
 
 --------------------
 
@@ -15,8 +11,8 @@ You need to have [Deno installed](https://deno.land/#installation) in order to r
 
 1. Clone the repository
 2. Go to the project root using terminal
-3. Run `deno run --allow-net server.js`
-4. Open `public/chat.html` in browser
+3. Run `deno run --allow-net --allow-read server.js`
+4. Open http://localhost:3000/chat.html` in browser
 5. That's all.
 
 

--- a/chat.js
+++ b/chat.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import { isWebSocketCloseEvent } from "https://deno.land/std/ws/mod.ts";
-import { v4 } from "https://deno.land/std/uuid/mod.ts";
+import { isWebSocketCloseEvent } from "https://deno.land/std@0.58.0/ws/mod.ts";
+import { v4 } from "https://deno.land/std@0.58.0/uuid/mod.ts";
 
 /**
  * userId: {

--- a/chat.js
+++ b/chat.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import { isWebSocketCloseEvent } from "https://deno.land/std@0.58.0/ws/mod.ts";
-import { v4 } from "https://deno.land/std@0.58.0/uuid/mod.ts";
+import { isWebSocketCloseEvent } from "https://deno.land/std@0.65.0/ws/mod.ts";
+import { v4 } from "https://deno.land/std@0.65.0/uuid/mod.ts";
 
 /**
  * userId: {

--- a/public/client.js
+++ b/public/client.js
@@ -9,7 +9,7 @@ let leaveGroupBtn = document.querySelector("#leaveGroupBtn");
 let groupName = document.querySelector("#groupName");
 
 window.addEventListener("DOMContentLoaded", () => {
-  ws = new WebSocket(`ws://localhost:3000/ws`);
+  ws = new WebSocket(`${window.location.protocol === 'http:' ? 'ws' : 'wss'}://${window.location.host}/ws`);
   ws.addEventListener("open", onConnectionOpen);
   ws.addEventListener("message", onMessageReceived);
 });

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
-import { listenAndServe } from "https://deno.land/std/http/server.ts";
-import { acceptWebSocket, acceptable } from "https://deno.land/std/ws/mod.ts";
+import { listenAndServe } from "https://deno.land/std@0.58.0/http/server.ts";
+import { acceptWebSocket, acceptable } from "https://deno.land/std@0.58.0/ws/mod.ts";
 import chat from "./chat.js";
 
 listenAndServe({ port: 3000 }, async (req) => {

--- a/server.js
+++ b/server.js
@@ -1,8 +1,36 @@
 import { listenAndServe } from "https://deno.land/std@0.58.0/http/server.ts";
+import { serveFile } from "https://deno.land/std@0.58.0/http/file_server.ts";
 import { acceptWebSocket, acceptable } from "https://deno.land/std@0.58.0/ws/mod.ts";
 import chat from "./chat.js";
 
+async function fileExists(path) {
+  try {
+    const stats = await Deno.lstat(path);
+    return stats && stats.isFile;
+  } catch(e) {
+    if (e && e instanceof Deno.errors.NotFound) {
+      return false;
+    } else {
+      throw e;
+    }
+  }
+}
+
 listenAndServe({ port: 3000 }, async (req) => {
+
+  const position = req.url.indexOf('?');
+
+  let url = req.url;
+  if (position > -1) {
+    url = req.url.substring(0, position);
+  }
+  const path = `${Deno.cwd()}/public${url}`; // /index.html
+  if (await fileExists(path)) {
+    const content = await serveFile(req, path);
+    req.respond(content);
+    return; 
+  }
+
   if (req.method === "GET" && req.url === "/ws") {
     if (acceptable(req)) {
       acceptWebSocket({

--- a/server.js
+++ b/server.js
@@ -22,12 +22,15 @@ const argPort = parse(Deno.args).port;
 const port = argPort ? parseInt(argPort) : DEFAULT_PORT
 
 listenAndServe({ port: port }, async (req) => {
+  let url = req.url;
+  if (req.method === 'GET' && url === '/') {
+    url = '/index.html';
+  }
 
   const position = req.url.indexOf('?');
-
-  let url = req.url;
+  
   if (position > -1) {
-    url = req.url.substring(0, position);
+    url = url.substring(0, position);
   }
   const path = `${Deno.cwd()}/public${url}`; // /index.html
   if (await fileExists(path)) {
@@ -47,4 +50,4 @@ listenAndServe({ port: port }, async (req) => {
     }
   }
 });
-console.log("Server started on port 3000");
+console.log(`Server started on port ${port}`);

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 import { listenAndServe } from "https://deno.land/std@0.58.0/http/server.ts";
 import { serveFile } from "https://deno.land/std@0.58.0/http/file_server.ts";
 import { acceptWebSocket, acceptable } from "https://deno.land/std@0.58.0/ws/mod.ts";
+import { parse } from "https://deno.land/std@0.59.0/flags/mod.ts";
 import chat from "./chat.js";
 
 async function fileExists(path) {
@@ -16,7 +17,11 @@ async function fileExists(path) {
   }
 }
 
-listenAndServe({ port: 3000 }, async (req) => {
+const DEFAULT_PORT = 3000;
+const argPort = parse(Deno.args).port;
+const port = argPort ? parseInt(argPort) : DEFAULT_PORT
+
+listenAndServe({ port: port }, async (req) => {
 
   const position = req.url.indexOf('?');
 

--- a/server.js
+++ b/server.js
@@ -1,14 +1,17 @@
-import { listenAndServe } from "https://deno.land/std@0.58.0/http/server.ts";
-import { serveFile } from "https://deno.land/std@0.58.0/http/file_server.ts";
-import { acceptWebSocket, acceptable } from "https://deno.land/std@0.58.0/ws/mod.ts";
-import { parse } from "https://deno.land/std@0.59.0/flags/mod.ts";
+import { listenAndServe } from "https://deno.land/std@0.67.0/http/server.ts";
+import { serveFile } from "https://deno.land/std@0.67.0/http/file_server.ts";
+import {
+  acceptWebSocket,
+  acceptable,
+} from "https://deno.land/std@0.67.0/ws/mod.ts";
+import { parse } from "https://deno.land/std@0.67.0/flags/mod.ts";
 import chat from "./chat.js";
 
 async function fileExists(path) {
   try {
     const stats = await Deno.lstat(path);
     return stats && stats.isFile;
-  } catch(e) {
+  } catch (e) {
     if (e && e instanceof Deno.errors.NotFound) {
       return false;
     } else {
@@ -19,16 +22,16 @@ async function fileExists(path) {
 
 const DEFAULT_PORT = 3000;
 const argPort = parse(Deno.args).port;
-const port = argPort ? parseInt(argPort) : DEFAULT_PORT
+const port = argPort ? parseInt(argPort) : DEFAULT_PORT;
 
 listenAndServe({ port: port }, async (req) => {
   let url = req.url;
-  if (req.method === 'GET' && url === '/') {
-    url = '/index.html';
+  if (req.method === "GET" && url === "/") {
+    url = "/index.html";
   }
 
-  const position = req.url.indexOf('?');
-  
+  const position = req.url.indexOf("?");
+
   if (position > -1) {
     url = url.substring(0, position);
   }
@@ -36,7 +39,7 @@ listenAndServe({ port: port }, async (req) => {
   if (await fileExists(path)) {
     const content = await serveFile(req, path);
     req.respond(content);
-    return; 
+    return;
   }
 
   if (req.method === "GET" && req.url === "/ws") {


### PR DESCRIPTION
In the current code, we are facing an issue while executing the command:
`deno run --allow-net --allow-read server.js`

They were caused by #6653. A version of std before 0.61.0 is incompatible with Deno 1.2.0. deno info main.ts will give you the dependency graph, and you can determine what dependencies need to be updated to they are using std 0.61.0.
[Check out the URL](https://github.com/denoland/deno/issues/6755)

I have updated the versions. This version will be user ready to fork and improve the code.